### PR TITLE
[codex] Harden package and build fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,8 @@ RUN locale-gen pt_BR.UTF-8 && \
 ENV LANG=pt_BR.UTF-8
 ENV LANGUAGE=pt_BR:pt
 ENV LC_ALL=pt_BR.UTF-8
+ENV PKG_BIN_DIR=/var/lib/devops-pkg/bin
+ENV PATH=/var/lib/devops-pkg/bin:${PATH}
 
 ############################################################
 # Atualiza o motd e bashrc (se arquivos existirem no contexto)

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,8 @@ help:
 
 build:
 	@mkdir -p "$(BUILD_CACHE_DIR)"; \
-	if docker buildx version >/dev/null 2>&1; then \
+	builder_driver="$$(docker buildx inspect 2>/dev/null | awk -F': ' '/^Driver:/ {print $$2; exit}')"; \
+	if docker buildx version >/dev/null 2>&1 && [ "$$builder_driver" != "docker" ]; then \
 	  docker buildx build $(BUILD_OPTS) \
 	    --cache-from type=local,src="$(BUILD_CACHE_DIR)" \
 	    --cache-to type=local,dest="$(BUILD_CACHE_DIR)",mode=max \

--- a/bin/pkg_add
+++ b/bin/pkg_add
@@ -63,7 +63,7 @@ try_run_sudo() {
     "$@"
   elif command -v sudo >/dev/null 2>&1; then
     if sudo -n true 2>/dev/null; then
-      sudo \
+      sudo env \
         PKG_BIN_DIR="${PKG_BIN_DIR:-}" \
         PKG_CACHE_DIR="${PKG_CACHE_DIR:-}" \
         PKG_CACHE_ENABLED="${PKG_CACHE_ENABLED:-}" \

--- a/utils.sh
+++ b/utils.sh
@@ -37,9 +37,14 @@ get_pkg_cache_dir() {
 
 # Diretório persistente para binários instalados sob demanda.
 get_pkg_bin_dir() {
-    local bin_dir="${PKG_BIN_DIR:-}"
-    if [ -n "$bin_dir" ] && mkdir -p "$bin_dir" 2>/dev/null && [ -w "$bin_dir" ]; then
+    local bin_dir="${PKG_BIN_DIR:-/var/lib/devops-pkg/bin}"
+    if mkdir -p "$bin_dir" 2>/dev/null && [ -w "$bin_dir" ]; then
         echo "$bin_dir"
+        return 0
+    fi
+
+    if [ "$bin_dir" != "/var/lib/devops-pkg/bin" ] && mkdir -p /var/lib/devops-pkg/bin 2>/dev/null && [ -w /var/lib/devops-pkg/bin ]; then
+        echo "/var/lib/devops-pkg/bin"
         return 0
     fi
 


### PR DESCRIPTION
What changed

- Fixed `pkg_add` so `sudo` preserves `PKG_BIN_DIR` and related paths.
- Made `get_pkg_bin_dir()` prefer `/var/lib/devops-pkg/bin` instead of falling back to `/root/.devops-pkg/bin`.
- Added `PKG_BIN_DIR` and `PATH` defaults in the image so `docker compose exec` shells see installed tools.
- Updated `Makefile` to use `buildx` only when the builder driver is not `docker`; otherwise it falls back to `docker build`.

Why

- The daemon on `note-zello` was using the older image and `make build` failed there because the local `buildx` driver does not support the cache export used by this repo.

Validation

- Rebuilt the image on `note-zello` with `docker build`.
- Recreated the compose daemon.
- Verified `aws --version` and the `/var/lib/devops-pkg/bin` mount inside the daemon.
